### PR TITLE
bump Appsflyer Carthage requirement to 4.8.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "AppsFlyerSDK/AppsFlyerFramework" == 4.7.3
+github "AppsFlyerSDK/AppsFlyerFramework" == 4.8.0
 github "mparticle/mparticle-apple-sdk" ~> 6.15.0


### PR DESCRIPTION
When I clone mparticle-apple-integration-appsflyer, run carthage update, and try to build the kit's Xcode project I get the following error:
```
MPKitAppsFlyer.m:280:32: Use of undeclared identifier 'AFEventParamOrderId'
```

It looks like the [kit code was updated to work with Appsflyer SDK 4.8.0](https://github.com/walmartlabs-wmusiphone/mparticle-apple-integration-appsflyer/commit/245d3e1882e92f8dfab91c76592dbd65f071dcd7) but the kit's Cartfile is still configured to install 4.7.3.

This change updates the Cartfile to use the version of Appsflyer that the kit code requires.