### PR TITLE
Mark as a static framework

### DIFF
--- a/mParticle-AppsFlyer.podspec
+++ b/mParticle-AppsFlyer.podspec
@@ -12,6 +12,8 @@ Pod::Spec.new do |s|
     s.author           = { "mParticle" => "support@mparticle.com" }
     s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-appsflyer.git", :tag => s.version.to_s }
     s.social_media_url = "https://twitter.com/mparticles"
+    
+    s.static_framework = true
 
     s.ios.deployment_target = "8.0"
     s.ios.source_files      = 'mParticle-AppsFlyer/*.{h,m,mm}'


### PR DESCRIPTION
This parameter makes Cocoapods know that we are integrating a static framework and avoids this error ```[!] The 'Pods-Saks' target has transitive dependencies that include static binaries: (/Users/edsancha/Workspace/saks-ios/Pods/AppsFlyerFramework/AppsFlyerLib.framework)
``` when using the `use_frameworks!` parameter
