### PR TITLE
Use ARCHS rather than EXCLUDED_ARCHS

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 binary "https://raw.githubusercontent.com/AppsFlyerSDK/AppsFlyerFramework/master/Carthage/appsflyer-ios.json" ~> 6.0
-github "mparticle/mparticle-apple-sdk" ~> 8.0
+github "sorinc03/mparticle-apple-sdk" ~> 8.0

--- a/mParticle-AppsFlyer.xcodeproj/project.pbxproj
+++ b/mParticle-AppsFlyer.xcodeproj/project.pbxproj
@@ -436,8 +436,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				EXCLUDED_ARCHS = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
+				ARCHS = "$(ARCHS_STANDARD)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -460,8 +459,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				EXCLUDED_ARCHS = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
+				ARCHS = "$(ARCHS_STANDARD)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",


### PR DESCRIPTION
## Summary
Add ARCHS to project config for Xcode 12 support and remove EXCLUDED_ARCHS since we should just be letting it decide what it wants to build.

## Testing Plan
Tested by fetching branch and building locally

## What does this fix?

Allows the framework to be built and run on the simulator

