### PR TITLE
Allow building for arm64 iOS simulators

### DIFF
--- a/mParticle-AppsFlyer.podspec
+++ b/mParticle-AppsFlyer.podspec
@@ -22,10 +22,6 @@ Pod::Spec.new do |s|
 
     s.ios.pod_target_xcconfig = {
         'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/AppsFlyerFramework/**',
-        'OTHER_LDFLAGS' => '$(inherited) -framework "AppsFlyerLib"',
-        'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
-    }
-    s.ios.user_target_xcconfig = {
-        'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
+        'OTHER_LDFLAGS' => '$(inherited) -framework "AppsFlyerLib"'
     }
 end


### PR DESCRIPTION
👋 Hello mParticle team! 

Our team will be transitioning to M1 computers soon. As part of this transition, we need to ensure that our app can build on the new machines. We noticed this pod disables our project from building on the arm64 simulator. 

I can confirm that removing the `EXCLUDED_ARCHS`  line allowed us to build the app successfully on our M1 Mac Mini on the iOS Simulator. Would love to get this merged in a release if possible. Please let me know if you have any questions!