### PR TITLE
feat: Update min version in SPM to match CocoaPods and Carthage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
                .upToNextMajor(from: "8.0.0")),
       .package(name: "AppsFlyerLib",
                url: "https://github.com/AppsFlyerSDK/AppsFlyerFramework",
-               .upToNextMajor(from: "6.2.4")),
+               .upToNextMajor(from: "6.8.0")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
 ## Summary
 This just updates the minimum version of the partner SDK to 6.8.0 to match CocoaPods and Carthage.

Note that we pin up to next major version so this doesn't actually change the version or really change anything at all, it just makes the minimum version explicit and brings it in line with the minimum version specified for the other 2 package managers.

 ## Testing Plan
 - Confirmed that it pulled the same version as before (latest version 6.11.0)

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5173
