### PR TITLE
feat: Add NoLocation target to SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,10 @@ let package = Package(
         .library(
             name: "mParticle-AppsFlyer",
             targets: ["mParticle-AppsFlyer"]),
+        .library(
+            name: "mParticle-AppsFlyer-NoLocation",
+            targets: ["mParticle-AppsFlyer-NoLocation"]
+        )
     ],
     dependencies: [
       .package(name: "mParticle-Apple-SDK",
@@ -23,9 +27,17 @@ let package = Package(
         .target(
             name: "mParticle-AppsFlyer",
             dependencies: [
-              .byName(name: "mParticle-Apple-SDK"),
+              .product(name: "mParticle-Apple-SDK", package: "mParticle-Apple-SDK"),
               .product(name: "AppsFlyerLib", package: "AppsFlyerLib"),
             ]
+        ),
+        .target(
+            name: "mParticle-AppsFlyer-NoLocation",
+            dependencies: [
+              .product(name: "mParticle-Apple-SDK-NoLocation", package: "mParticle-Apple-SDK"),
+              .product(name: "AppsFlyerLib", package: "AppsFlyerLib"),
+            ],
+            path: "SPM/mParticle-AppsFlyer-NoLocation"
         )
     ]
 )

--- a/SPM/mParticle-Appsflyer-NoLocation
+++ b/SPM/mParticle-Appsflyer-NoLocation
@@ -1,0 +1,1 @@
+../Sources/mParticle-AppsFlyer

--- a/Sources/mParticle-AppsFlyer/include/MPKitAppsFlyer.h
+++ b/Sources/mParticle-AppsFlyer/include/MPKitAppsFlyer.h
@@ -1,8 +1,10 @@
 #import <Foundation/Foundation.h>
 #if defined(__has_include) && __has_include(<mParticle_Apple_SDK/mParticle.h>)
-#import <mParticle_Apple_SDK/mParticle.h>
+    #import <mParticle_Apple_SDK/mParticle.h>
+#elif defined(__has_include) && __has_include(<mParticle_Apple_SDK_NoLocation/mParticle.h>)
+    #import <mParticle_Apple_SDK_NoLocation/mParticle.h>
 #else
-#import "mParticle.h"
+    #import "mParticle.h"
 #endif
 
 extern NSString * _Nonnull const MPKitAppsFlyerConversionResultKey;

--- a/Sources/mParticle-AppsFlyer/include/mParticle_AppsFlyer.h
+++ b/Sources/mParticle-AppsFlyer/include/mParticle_AppsFlyer.h
@@ -9,9 +9,11 @@ FOUNDATION_EXPORT const unsigned char mParticle_AppsFlyerVersionString[];
 // In this header, you should import all the public headers of your framework using statements like #import <mParticle_AppsFlyer/PublicHeader.h>
 
 #if defined(__has_include) && __has_include(<mParticle_AppsFlyer/MPKitAppsFlyer.h>)
-#import <mParticle_AppsFlyer/MPKitAppsFlyer.h>
+    #import <mParticle_AppsFlyer/MPKitAppsFlyer.h>
+#elif defined(__has_include) && __has_include(<mParticle_AppsFlyer_NoLocation/MPKitAppsFlyer.h>)
+    #import <mParticle_AppsFlyer/MPKitAppsFlyer.h>
 #else
-#import "MPKitAppsFlyer.h"
+    #import "MPKitAppsFlyer.h"
 #endif
 
 


### PR DESCRIPTION
 ## Summary
Add dedicated NoLocation target to SPM with a dependency on the NoLocation version of the mParticle SDK. This prevents the issue where a customer adds the NoLocation SDK and then the kit depends on the standard version, which causes both to be included.

 ## Testing Plan
- Confirmed in a test app that both targets work as expected

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5439