### PR TITLE
fix: Update Appsflyer SPM dependency to new repo

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
                url: "https://github.com/mParticle/mparticle-apple-sdk",
                .upToNextMajor(from: "8.0.0")),
       .package(name: "AppsFlyerLib",
-               url: "https://github.com/AppsFlyerSDK/AppsFlyerFramework",
+               url: "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Static",
                .upToNextMajor(from: "6.8.0")),
     ],
     targets: [
@@ -28,14 +28,14 @@ let package = Package(
             name: "mParticle-AppsFlyer",
             dependencies: [
               .product(name: "mParticle-Apple-SDK", package: "mParticle-Apple-SDK"),
-              .product(name: "AppsFlyerLib", package: "AppsFlyerLib"),
+              .product(name: "AppsFlyerLib-Static", package: "AppsFlyerLib"),
             ]
         ),
         .target(
             name: "mParticle-AppsFlyer-NoLocation",
             dependencies: [
               .product(name: "mParticle-Apple-SDK-NoLocation", package: "mParticle-Apple-SDK"),
-              .product(name: "AppsFlyerLib", package: "AppsFlyerLib"),
+              .product(name: "AppsFlyerLib-Static", package: "AppsFlyerLib"),
             ],
             path: "SPM/mParticle-AppsFlyer-NoLocation"
         )

--- a/Sources/mParticle-AppsFlyer/PrivacyInfo.xcprivacy
+++ b/Sources/mParticle-AppsFlyer/PrivacyInfo.xcprivacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array>
+        <dict/>
+    </array>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict/>
+    </array>
+</dict>
+</plist>

--- a/mParticle-AppsFlyer.xcodeproj/project.pbxproj
+++ b/mParticle-AppsFlyer.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -32,11 +32,10 @@
 		04EE54D22020DD2C0063CF75 /* mParticle_AppsFlyerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = mParticle_AppsFlyerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		04EE54D42020DD2C0063CF75 /* mParticle_AppsFlyerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = mParticle_AppsFlyerTests.m; sourceTree = "<group>"; };
 		04EE54D62020DD2C0063CF75 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		21E5883028D967EF00A45325 /* mParticle_Apple_SDK.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = mParticle_Apple_SDK.xcframework; path = Carthage/Build/mParticle_Apple_SDK.xcframework; sourceTree = "<group>"; };
+		21E5883028D967EF00A45325 /* mParticle_Apple_SDK.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:DLD43Y3TRP:mParticle, inc"; lastKnownFileType = wrapper.xcframework; name = mParticle_Apple_SDK.xcframework; path = Carthage/Build/mParticle_Apple_SDK.xcframework; sourceTree = "<group>"; };
 		21E5883228D967FB00A45325 /* AppsFlyerLib.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = AppsFlyerLib.xcframework; path = Carthage/Build/AppsFlyerLib.xcframework; sourceTree = "<group>"; };
 		21E5883728D968CE00A45325 /* OCMock.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = OCMock.xcframework; path = Carthage/Build/OCMock.xcframework; sourceTree = "<group>"; };
 		53F648D22BBB57A500708E8A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		D377138923FDEB5A00CF4773 /* OCMock.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OCMock.framework; sourceTree = "<group>"; };
 		DB5DF5D52624A893004BBEC9 /* mParticle_AppsFlyer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mParticle_AppsFlyer.h; sourceTree = "<group>"; };
 		DB5DF5D62624A893004BBEC9 /* MPKitAppsFlyer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPKitAppsFlyer.h; sourceTree = "<group>"; };
 		DBB8BF891DB9596D00FA55C3 /* mParticle_AppsFlyer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = mParticle_AppsFlyer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -79,7 +78,6 @@
 			isa = PBXGroup;
 			children = (
 				21E5883728D968CE00A45325 /* OCMock.xcframework */,
-				D377138923FDEB5A00CF4773 /* OCMock.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -284,7 +282,6 @@
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = mParticle_AppsFlyerTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -318,7 +315,6 @@
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = mParticle_AppsFlyerTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -371,7 +367,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -416,7 +412,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -441,7 +437,6 @@
 				);
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -468,7 +463,6 @@
 				);
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/mParticle-AppsFlyer.xcodeproj/project.pbxproj
+++ b/mParticle-AppsFlyer.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -12,6 +12,7 @@
 		21E5883328D967FB00A45325 /* AppsFlyerLib.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21E5883228D967FB00A45325 /* AppsFlyerLib.xcframework */; };
 		21E5883528D9683600A45325 /* AppsFlyerLib.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21E5883228D967FB00A45325 /* AppsFlyerLib.xcframework */; };
 		21E5883828D968CE00A45325 /* OCMock.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21E5883728D968CE00A45325 /* OCMock.xcframework */; };
+		53F648D32BBB57A500708E8A /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 53F648D22BBB57A500708E8A /* PrivacyInfo.xcprivacy */; };
 		DB5DF5D72624A893004BBEC9 /* mParticle_AppsFlyer.h in Headers */ = {isa = PBXBuildFile; fileRef = DB5DF5D52624A893004BBEC9 /* mParticle_AppsFlyer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB5DF5D82624A893004BBEC9 /* MPKitAppsFlyer.h in Headers */ = {isa = PBXBuildFile; fileRef = DB5DF5D62624A893004BBEC9 /* MPKitAppsFlyer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DBB8BF971DB95A2C00FA55C3 /* MPKitAppsFlyer.m in Sources */ = {isa = PBXBuildFile; fileRef = DBB8BF951DB95A2C00FA55C3 /* MPKitAppsFlyer.m */; };
@@ -34,6 +35,7 @@
 		21E5883028D967EF00A45325 /* mParticle_Apple_SDK.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = mParticle_Apple_SDK.xcframework; path = Carthage/Build/mParticle_Apple_SDK.xcframework; sourceTree = "<group>"; };
 		21E5883228D967FB00A45325 /* AppsFlyerLib.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = AppsFlyerLib.xcframework; path = Carthage/Build/AppsFlyerLib.xcframework; sourceTree = "<group>"; };
 		21E5883728D968CE00A45325 /* OCMock.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = OCMock.xcframework; path = Carthage/Build/OCMock.xcframework; sourceTree = "<group>"; };
+		53F648D22BBB57A500708E8A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D377138923FDEB5A00CF4773 /* OCMock.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OCMock.framework; sourceTree = "<group>"; };
 		DB5DF5D52624A893004BBEC9 /* mParticle_AppsFlyer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mParticle_AppsFlyer.h; sourceTree = "<group>"; };
 		DB5DF5D62624A893004BBEC9 /* MPKitAppsFlyer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPKitAppsFlyer.h; sourceTree = "<group>"; };
@@ -118,6 +120,7 @@
 			children = (
 				DB5DF5D42624A893004BBEC9 /* include */,
 				DBB8BF951DB95A2C00FA55C3 /* MPKitAppsFlyer.m */,
+				53F648D22BBB57A500708E8A /* PrivacyInfo.xcprivacy */,
 			);
 			name = "mParticle-AppsFlyer";
 			path = "Sources/mParticle-AppsFlyer";
@@ -225,6 +228,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				53F648D32BBB57A500708E8A /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/mParticle_AppsFlyerTests/mParticle_AppsFlyerTests.m
+++ b/mParticle_AppsFlyerTests/mParticle_AppsFlyerTests.m
@@ -111,7 +111,7 @@ NSString *const afDevKey = @"devKey";
     [event addProduct:product3];
     
     NSDictionary *resultValues = @{
-        @"af_customer_user_id" : @"0",
+        @"af_customer_user_id" : @"2",
         @"af_quantity" : @7,
         @"test": @"Malarkey",
         @"af_content_id" : @"foo-sku,foo-sku-2,foo-sku-%2C3"
@@ -140,7 +140,7 @@ NSString *const afDevKey = @"devKey";
     [event addProduct:product3];
     
     NSDictionary *resultValues = @{
-        @"af_customer_user_id" : @"0",
+        @"af_customer_user_id" : @"2",
         @"af_quantity" : @7,
         @"af_content_id" : @"foo-sku,foo-sku-2,foo-sku-%2C3"
     };


### PR DESCRIPTION
 ## Summary
 - Points to fixed AppsFlyer SPM repo (still uses static version like we've always done)
 - Added Privacy Manifest
 - Fixed the unit test target and 2 failing tests

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Added to a test apps using both SPM and Cocoapods and ran unit tests

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6288
