### PR TITLE
chore: Update to Version 9.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     dependencies: [
       .package(name: "mParticle-Apple-SDK",
                url: "https://github.com/mParticle/mparticle-apple-sdk",
-               .upToNextMajor(from: "8.19.0")),
+               .upToNextMajor(from: "9.0.0")),
       .package(name: "AppsFlyerLib",
                url: "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Static",
                .upToNextMajor(from: "6.14.3")),

--- a/mParticle-AppsFlyer.podspec
+++ b/mParticle-AppsFlyer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "mParticle-AppsFlyer"
-    s.version          = "8.4.2"
+    s.version          = "9.0.0"
     s.summary          = "AppsFlyer integration for mParticle"
 
     s.description      = <<-DESC
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "12.0"
     s.ios.source_files      = 'Sources/**/*.{h,m,mm}'
     s.ios.resource_bundles  = { 'mParticle-AppsFlyer-Privacy' => ['Sources/mParticle-AppsFlyer/PrivacyInfo.xcprivacy'] }
-    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.19'
+    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 9.0'
     s.ios.dependency 'AppsFlyerFramework', '~> 6.16'
 end


### PR DESCRIPTION
## Summary
 - Bumps the integration version from 8.11.1 to 9.0.0
 - Updates the mParticle-Apple-SDK dependency to ~> 9.0 for both iOS and tvOS platforms in the podspec
 - Updates the Swift Package Manager dependency to .upToNextMajor(from: "9.0.0") in Package.swift

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://rokt.atlassian.net/browse/SDKE-773
