### PR TITLE
feat: Add setSharingFilterForPartners support

### DIFF
--- a/Sources/mParticle-AppsFlyer/MPKitAppsFlyer.m
+++ b/Sources/mParticle-AppsFlyer/MPKitAppsFlyer.m
@@ -18,6 +18,7 @@ NSString *const MPKitAppsFlyerErrorDomain = @"mParticle-AppsFlyer";
 
 NSString *const afAppleAppId = @"appleAppId";
 NSString *const afDevKey = @"devKey";
+NSString *const afSharingFilterForPartners = @"sharingFilterForPartners";
 NSString *const afAppsFlyerIdIntegrationKey = @"appsflyer_id_integration_setting";
 NSString *const kMPKAFCustomerUserId = @"af_customer_user_id";
 
@@ -111,6 +112,11 @@ static id<AppsFlyerLibDelegate> temporaryDelegate = nil;
     appsFlyerTracker.deepLinkDelegate = self;
     
     _configuration = configuration;
+
+    NSArray<NSString *> *sharingFilter = [self sharingFilterForPartnersFromConfiguration:configuration];
+    if (sharingFilter.count > 0) {
+        [appsFlyerTracker setSharingFilterForPartners:sharingFilter];
+    }
 
     [self updateConsent];
     [appsFlyerTracker waitForATTUserAuthorizationWithTimeoutInterval:60];
@@ -569,6 +575,35 @@ static id<AppsFlyerLibDelegate> temporaryDelegate = nil;
 
 - (FilteredMParticleUser *)currentUser {
     return [[self kitApi] getCurrentUserWithKit:self];
+}
+
+- (NSArray<NSString *> *)sharingFilterForPartnersFromConfiguration:(NSDictionary *)configuration {
+    id value = configuration[afSharingFilterForPartners];
+    if (!value) {
+        return nil;
+    }
+
+    NSArray *partnerIds = nil;
+    if ([value isKindOfClass:[NSArray class]]) {
+        partnerIds = value;
+    } else if ([value isKindOfClass:[NSString class]]) {
+        NSData *jsonData = [value dataUsingEncoding:NSUTF8StringEncoding];
+        NSError *error;
+        partnerIds = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
+        if (error || ![partnerIds isKindOfClass:[NSArray class]]) {
+            return nil;
+        }
+    } else {
+        return nil;
+    }
+
+    NSMutableArray<NSString *> *result = [NSMutableArray arrayWithCapacity:partnerIds.count];
+    for (id item in partnerIds) {
+        if ([item isKindOfClass:[NSString class]] && ((NSString *)item).length > 0) {
+            [result addObject:item];
+        }
+    }
+    return result.count > 0 ? [result copy] : nil;
 }
 
 @end

--- a/Sources/mParticle-AppsFlyer/include/MPKitAppsFlyer.h
+++ b/Sources/mParticle-AppsFlyer/include/MPKitAppsFlyer.h
@@ -33,6 +33,8 @@ extern NSString * _Nonnull const MPKitAppsFlyerErrorDomain;
 
 - (nullable NSArray<NSDictionary *>*)mappingForKey:(NSString* _Nonnull)key;
 
+- (nullable NSArray<NSString *> *)sharingFilterForPartnersFromConfiguration:(NSDictionary * _Nonnull)configuration;
+
 - (nonnull NSDictionary*)convertToKeyValuePairs: (NSArray<NSDictionary *> * _Nonnull)mappings;
 
 - (nonnull MPKitExecStatus *)routeCommerceEvent:(nonnull MPCommerceEvent *)commerceEvent;

--- a/mParticle_AppsFlyerTests/MPKitAppsFlyerTests.swift
+++ b/mParticle_AppsFlyerTests/MPKitAppsFlyerTests.swift
@@ -74,6 +74,32 @@ final class MPKitAppsFlyerTests: XCTestCase {
         XCTAssertNil(result)
     }
 
+    // MARK: - sharingFilterForPartnersFromConfiguration
+
+    func test_sharingFilterForPartners_validJSON_returnsList() {
+        kit.configuration["sharingFilterForPartners"] = #"["partner_1", "partner_2"]"#
+        let result = kit.sharingFilterForPartners(fromConfiguration: kit.configuration)
+        XCTAssertEqual(result, ["partner_1", "partner_2"])
+    }
+
+    func test_sharingFilterForPartners_emptyOrMissing_returnsNil() {
+        XCTAssertNil(kit.sharingFilterForPartners(fromConfiguration: [:]))
+        kit.configuration["sharingFilterForPartners"] = ""
+        XCTAssertNil(kit.sharingFilterForPartners(fromConfiguration: kit.configuration))
+    }
+
+    func test_sharingFilterForPartners_invalidJSON_returnsNil() {
+        kit.configuration["sharingFilterForPartners"] = "not a json array"
+        let result = kit.sharingFilterForPartners(fromConfiguration: kit.configuration)
+        XCTAssertNil(result)
+    }
+
+    func test_sharingFilterForPartners_invalidEscapedJSON_returnsNil() {
+        kit.configuration["sharingFilterForPartners"] = #"[\"test_1\", \"test_2\"]"#
+        let result = kit.sharingFilterForPartners(fromConfiguration: kit.configuration)
+        XCTAssertNil(result)
+    }
+
     // MARK: - resolvedConsentForMappingKey
 
     func test_resolvedConsentForMappingKey_withGDPRMapping_returnsTrue() {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
Add support in the mParticle AppsFlyer Kit integration to leverage AppsFlyer’s setSharingFilterForPartners parameter, enabling customers to control which partner(s) AppsFlyer shares data with.

Copy of: https://github.com/mParticle/mparticle-apple-sdk/pull/632

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://rokt.atlassian.net/browse/SDKE-886
