### PR TITLE
feat: Allow Client to Manually Call Appsflyer Start

### DIFF
--- a/Sources/mParticle-AppsFlyer/MPKitAppsFlyer.m
+++ b/Sources/mParticle-AppsFlyer/MPKitAppsFlyer.m
@@ -19,8 +19,6 @@ NSString *const MPKitAppsFlyerErrorDomain = @"mParticle-AppsFlyer";
 NSString *const afAppleAppId = @"appleAppId";
 NSString *const afDevKey = @"devKey";
 NSString *const afManualStart = @"manualStart";
-NSString *const afUserIdentificationType = @"userIdentificationType";
-NSString *const afUserIdentificationMPID = @"MPID";
 NSString *const afAppsFlyerIdIntegrationKey = @"appsflyer_id_integration_setting";
 NSString *const kMPKAFCustomerUserId = @"af_customer_user_id";
 
@@ -115,8 +113,6 @@ static id<AppsFlyerLibDelegate> temporaryDelegate = nil;
     
     _configuration = configuration;
     
-    [self updateCustomerUserIDIfNeededForUser:[self currentUser]];
-
     [self updateConsent];
     [appsFlyerTracker waitForATTUserAuthorizationWithTimeoutInterval:60];
     [self start];
@@ -201,9 +197,7 @@ static id<AppsFlyerLibDelegate> temporaryDelegate = nil;
 
 - (nonnull MPKitExecStatus *)setUserIdentity:(nullable NSString *)identityString identityType:(MPUserIdentity)identityType {
     MPKitExecStatus *execStatus;
-    if ([self isUserIdentificationMPID]) {
-        execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeSuccess];
-    } else if (identityType == MPUserIdentityCustomerId) {
+    if (identityType == MPUserIdentityCustomerId) {
         [appsFlyerTracker setCustomerUserID:identityString];
         execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeSuccess];
     } else if (identityType == MPUserIdentityEmail) {
@@ -218,26 +212,6 @@ static id<AppsFlyerLibDelegate> temporaryDelegate = nil;
         execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeFail];
     }
     return execStatus;
-}
-
-- (nonnull MPKitExecStatus *)onIdentifyComplete:(nonnull FilteredMParticleUser *)user request:(nonnull FilteredMPIdentityApiRequest *)request {
-    [self updateCustomerUserIDIfNeededForUser:user];
-    return [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeSuccess];
-}
-
-- (nonnull MPKitExecStatus *)onLoginComplete:(nonnull FilteredMParticleUser *)user request:(nonnull FilteredMPIdentityApiRequest *)request {
-    [self updateCustomerUserIDIfNeededForUser:user];
-    return [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeSuccess];
-}
-
-- (nonnull MPKitExecStatus *)onLogoutComplete:(nonnull FilteredMParticleUser *)user request:(nonnull FilteredMPIdentityApiRequest *)request {
-    [self updateCustomerUserIDIfNeededForUser:user];
-    return [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeSuccess];
-}
-
-- (nonnull MPKitExecStatus *)onModifyComplete:(nonnull FilteredMParticleUser *)user request:(nonnull FilteredMPIdentityApiRequest *)request {
-    [self updateCustomerUserIDIfNeededForUser:user];
-    return [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeSuccess];
 }
 
 + (NSString * _Nullable)generateProductIdList:(nullable MPCommerceEvent *)event {
@@ -599,18 +573,6 @@ static id<AppsFlyerLibDelegate> temporaryDelegate = nil;
 
 - (FilteredMParticleUser *)currentUser {
     return [[self kitApi] getCurrentUserWithKit:self];
-}
-
-- (BOOL)isUserIdentificationMPID {
-    return [afUserIdentificationMPID isEqualToString:_configuration[afUserIdentificationType]];
-}
-
-- (void)updateCustomerUserIDIfNeededForUser:(FilteredMParticleUser *)user {
-    if (![self isUserIdentificationMPID] || !user.userId) {
-        return;
-    }
-    NSString *customerId = [user.userId stringValue];
-    [appsFlyerTracker setCustomerUserID:customerId];
 }
 
 @end

--- a/Sources/mParticle-AppsFlyer/MPKitAppsFlyer.m
+++ b/Sources/mParticle-AppsFlyer/MPKitAppsFlyer.m
@@ -18,7 +18,9 @@ NSString *const MPKitAppsFlyerErrorDomain = @"mParticle-AppsFlyer";
 
 NSString *const afAppleAppId = @"appleAppId";
 NSString *const afDevKey = @"devKey";
-NSString *const afSharingFilterForPartners = @"sharingFilterForPartners";
+NSString *const afManualStart = @"manualStart";
+NSString *const afUserIdentificationType = @"userIdentificationType";
+NSString *const afUserIdentificationMPID = @"MPID";
 NSString *const afAppsFlyerIdIntegrationKey = @"appsflyer_id_integration_setting";
 NSString *const kMPKAFCustomerUserId = @"af_customer_user_id";
 
@@ -112,11 +114,8 @@ static id<AppsFlyerLibDelegate> temporaryDelegate = nil;
     appsFlyerTracker.deepLinkDelegate = self;
     
     _configuration = configuration;
-
-    NSArray<NSString *> *sharingFilter = [self sharingFilterForPartnersFromConfiguration:configuration];
-    if (sharingFilter.count > 0) {
-        [appsFlyerTracker setSharingFilterForPartners:sharingFilter];
-    }
+    
+    [self updateCustomerUserIDIfNeededForUser:[self currentUser]];
 
     [self updateConsent];
     [appsFlyerTracker waitForATTUserAuthorizationWithTimeoutInterval:60];
@@ -151,7 +150,10 @@ static id<AppsFlyerLibDelegate> temporaryDelegate = nil;
 }
 
 - (nonnull MPKitExecStatus *)didBecomeActive {
-    [appsFlyerTracker start];
+    BOOL manualStart = [_configuration[afManualStart] boolValue];
+    if (!manualStart) {
+        [appsFlyerTracker start];
+    }
     MPKitExecStatus *execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeSuccess];
     return execStatus;
 }
@@ -199,7 +201,9 @@ static id<AppsFlyerLibDelegate> temporaryDelegate = nil;
 
 - (nonnull MPKitExecStatus *)setUserIdentity:(nullable NSString *)identityString identityType:(MPUserIdentity)identityType {
     MPKitExecStatus *execStatus;
-    if (identityType == MPUserIdentityCustomerId) {
+    if ([self isUserIdentificationMPID]) {
+        execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeSuccess];
+    } else if (identityType == MPUserIdentityCustomerId) {
         [appsFlyerTracker setCustomerUserID:identityString];
         execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeSuccess];
     } else if (identityType == MPUserIdentityEmail) {
@@ -214,6 +218,26 @@ static id<AppsFlyerLibDelegate> temporaryDelegate = nil;
         execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeFail];
     }
     return execStatus;
+}
+
+- (nonnull MPKitExecStatus *)onIdentifyComplete:(nonnull FilteredMParticleUser *)user request:(nonnull FilteredMPIdentityApiRequest *)request {
+    [self updateCustomerUserIDIfNeededForUser:user];
+    return [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeSuccess];
+}
+
+- (nonnull MPKitExecStatus *)onLoginComplete:(nonnull FilteredMParticleUser *)user request:(nonnull FilteredMPIdentityApiRequest *)request {
+    [self updateCustomerUserIDIfNeededForUser:user];
+    return [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeSuccess];
+}
+
+- (nonnull MPKitExecStatus *)onLogoutComplete:(nonnull FilteredMParticleUser *)user request:(nonnull FilteredMPIdentityApiRequest *)request {
+    [self updateCustomerUserIDIfNeededForUser:user];
+    return [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeSuccess];
+}
+
+- (nonnull MPKitExecStatus *)onModifyComplete:(nonnull FilteredMParticleUser *)user request:(nonnull FilteredMPIdentityApiRequest *)request {
+    [self updateCustomerUserIDIfNeededForUser:user];
+    return [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeSuccess];
 }
 
 + (NSString * _Nullable)generateProductIdList:(nullable MPCommerceEvent *)event {
@@ -577,33 +601,16 @@ static id<AppsFlyerLibDelegate> temporaryDelegate = nil;
     return [[self kitApi] getCurrentUserWithKit:self];
 }
 
-- (NSArray<NSString *> *)sharingFilterForPartnersFromConfiguration:(NSDictionary *)configuration {
-    id value = configuration[afSharingFilterForPartners];
-    if (!value) {
-        return nil;
-    }
+- (BOOL)isUserIdentificationMPID {
+    return [afUserIdentificationMPID isEqualToString:_configuration[afUserIdentificationType]];
+}
 
-    NSArray *partnerIds = nil;
-    if ([value isKindOfClass:[NSArray class]]) {
-        partnerIds = value;
-    } else if ([value isKindOfClass:[NSString class]]) {
-        NSData *jsonData = [value dataUsingEncoding:NSUTF8StringEncoding];
-        NSError *error;
-        partnerIds = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
-        if (error || ![partnerIds isKindOfClass:[NSArray class]]) {
-            return nil;
-        }
-    } else {
-        return nil;
+- (void)updateCustomerUserIDIfNeededForUser:(FilteredMParticleUser *)user {
+    if (![self isUserIdentificationMPID] || !user.userId) {
+        return;
     }
-
-    NSMutableArray<NSString *> *result = [NSMutableArray arrayWithCapacity:partnerIds.count];
-    for (id item in partnerIds) {
-        if ([item isKindOfClass:[NSString class]] && ((NSString *)item).length > 0) {
-            [result addObject:item];
-        }
-    }
-    return result.count > 0 ? [result copy] : nil;
+    NSString *customerId = [user.userId stringValue];
+    [appsFlyerTracker setCustomerUserID:customerId];
 }
 
 @end

--- a/Sources/mParticle-AppsFlyer/include/MPKitAppsFlyer.h
+++ b/Sources/mParticle-AppsFlyer/include/MPKitAppsFlyer.h
@@ -33,8 +33,6 @@ extern NSString * _Nonnull const MPKitAppsFlyerErrorDomain;
 
 - (nullable NSArray<NSDictionary *>*)mappingForKey:(NSString* _Nonnull)key;
 
-- (nullable NSArray<NSString *> *)sharingFilterForPartnersFromConfiguration:(NSDictionary * _Nonnull)configuration;
-
 - (nonnull NSDictionary*)convertToKeyValuePairs: (NSArray<NSDictionary *> * _Nonnull)mappings;
 
 - (nonnull MPKitExecStatus *)routeCommerceEvent:(nonnull MPCommerceEvent *)commerceEvent;

--- a/mParticle_AppsFlyerTests/AppsFlyerLibMock.swift
+++ b/mParticle_AppsFlyerTests/AppsFlyerLibMock.swift
@@ -11,7 +11,12 @@ class AppsFlyerLibMock: AppsFlyerLib {
     var logEventCalled = false
     var logEventEventName: String?
     var logEventValues: [AnyHashable : Any]?
-    
+    var startCallCount = 0
+
+    override func start() {
+        startCallCount += 1
+    }
+
     override func logEvent(_ eventName: String, withValues values: [AnyHashable : Any]?) {
         logEventCalled = true
         logEventEventName = eventName

--- a/mParticle_AppsFlyerTests/MPKitAppsFlyerTests.swift
+++ b/mParticle_AppsFlyerTests/MPKitAppsFlyerTests.swift
@@ -74,30 +74,33 @@ final class MPKitAppsFlyerTests: XCTestCase {
         XCTAssertNil(result)
     }
 
-    // MARK: - sharingFilterForPartnersFromConfiguration
+    // MARK: - didBecomeActive / manualStart
 
-    func test_sharingFilterForPartners_validJSON_returnsList() {
-        kit.configuration["sharingFilterForPartners"] = #"["partner_1", "partner_2"]"#
-        let result = kit.sharingFilterForPartners(fromConfiguration: kit.configuration)
-        XCTAssertEqual(result, ["partner_1", "partner_2"])
+    func test_didBecomeActive_manualStartTrue_doesNotCallAppsFlyerStart() {
+        kit.configuration = ["manualStart": true]
+        kit.providerKitInstance = mock
+
+        _ = kit.didBecomeActive()
+
+        XCTAssertEqual(mock.startCallCount, 0)
     }
 
-    func test_sharingFilterForPartners_emptyOrMissing_returnsNil() {
-        XCTAssertNil(kit.sharingFilterForPartners(fromConfiguration: [:]))
-        kit.configuration["sharingFilterForPartners"] = ""
-        XCTAssertNil(kit.sharingFilterForPartners(fromConfiguration: kit.configuration))
+    func test_didBecomeActive_manualStartFalse_callsAppsFlyerStart() {
+        kit.configuration = ["manualStart": false]
+        kit.providerKitInstance = mock
+
+        _ = kit.didBecomeActive()
+
+        XCTAssertEqual(mock.startCallCount, 1)
     }
 
-    func test_sharingFilterForPartners_invalidJSON_returnsNil() {
-        kit.configuration["sharingFilterForPartners"] = "not a json array"
-        let result = kit.sharingFilterForPartners(fromConfiguration: kit.configuration)
-        XCTAssertNil(result)
-    }
+    func test_didBecomeActive_manualStartOmitted_callsAppsFlyerStart() {
+        kit.configuration = [:]
+        kit.providerKitInstance = mock
 
-    func test_sharingFilterForPartners_invalidEscapedJSON_returnsNil() {
-        kit.configuration["sharingFilterForPartners"] = #"[\"test_1\", \"test_2\"]"#
-        let result = kit.sharingFilterForPartners(fromConfiguration: kit.configuration)
-        XCTAssertNil(result)
+        _ = kit.didBecomeActive()
+
+        XCTAssertEqual(mock.startCallCount, 1)
     }
 
     // MARK: - resolvedConsentForMappingKey


### PR DESCRIPTION
## Summary
 - Only call AppsFlyer start when manual start flag is false
 - Remove setSharingFilterForPartners logic
 - Send MPID based off new flag

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes MPID as customer ID https://go.mparticle.com/work/TRIAGE-189
 - Closes manual start https://go.mparticle.com/work/SDKE-1142

