### PR TITLE
ci: Update versions of macos and checkout in CI/CD

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -17,14 +17,14 @@ jobs:
     # Job name is Test
     name: Test
     # This job runs on macOS
-    runs-on: macOS-latest
+    runs-on: macos-14
     strategy:
       matrix:
-        destination: ['platform=iOS Simulator,OS=14.0,name=iPhone 8']
+        destination: ['platform=iOS Simulator,OS=17.2,name=iPhone 15']
         xcode: ['/Applications/Xcode.app/Contents/Developer']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Dependencies
         run: |
           sudo gem install cocoapods

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -24,7 +24,7 @@ jobs:
         xcode: ['/Applications/Xcode.app/Contents/Developer']
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Dependencies
         run: |
           sudo gem install cocoapods

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -17,10 +17,10 @@ jobs:
     # Job name is Test
     name: Test
     # This job runs on macOS
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       matrix:
-        destination: ['platform=iOS Simulator,OS=17.2,name=iPhone 15']
+        destination: ['platform=iOS Simulator,OS=18.5,name=iPhone 16']
         xcode: ['/Applications/Xcode.app/Contents/Developer']
     steps:
       - name: Checkout

--- a/.github/workflows/ios-kit-release.yml
+++ b/.github/workflows/ios-kit-release.yml
@@ -20,7 +20,7 @@ jobs:
     needs: confirm-main-branch
     steps:
       - name: Checkout development branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.repository }}
           token: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
@@ -40,7 +40,7 @@ jobs:
       COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate environment
         run: |
@@ -53,7 +53,7 @@ jobs:
           git config user.name "mParticle Automation"
 
       - name: Checkout main branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           repository: ${{ github.repository }}
@@ -117,7 +117,7 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           repository: ${{ github.repository }}

--- a/.github/workflows/ios-kit-release.yml
+++ b/.github/workflows/ios-kit-release.yml
@@ -16,11 +16,11 @@ jobs:
 
   create-release-branch:
     name: Create release branch
-    runs-on: macOS-12
+    runs-on: macos-14
     needs: confirm-main-branch
     steps:
       - name: Checkout development branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
           token: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
@@ -33,14 +33,14 @@ jobs:
 
   release:
     name: Perform release
-    runs-on: macOS-12
+    runs-on: macos-14
     needs: create-release-branch
     env:
       GITHUB_ACCESS_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
       COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Validate environment
         run: |
@@ -53,7 +53,7 @@ jobs:
           git config user.name "mParticle Automation"
 
       - name: Checkout main branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           repository: ${{ github.repository }}
@@ -114,10 +114,10 @@ jobs:
   sync-repository:
     name: Finalize release
     needs: release
-    runs-on: macOS-12
+    runs-on: macos-14
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           repository: ${{ github.repository }}

--- a/.github/workflows/ios-kit-release.yml
+++ b/.github/workflows/ios-kit-release.yml
@@ -16,7 +16,7 @@ jobs:
 
   create-release-branch:
     name: Create release branch
-    runs-on: macos-14
+    runs-on: macos-15
     needs: confirm-main-branch
     steps:
       - name: Checkout development branch
@@ -33,7 +33,7 @@ jobs:
 
   release:
     name: Perform release
-    runs-on: macos-14
+    runs-on: macos-15
     needs: create-release-branch
     env:
       GITHUB_ACCESS_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
@@ -114,7 +114,7 @@ jobs:
   sync-repository:
     name: Finalize release
     needs: release
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Checkout main branch
         uses: actions/checkout@v6


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
The "Create release branch" job specifies runs-on: macOS-12, and macOS-12 (Monterey) runners have been deprecated and removed by GitHub. GitHub removed macOS-12 runners in late 2024/early 2025. Since there are no available runners matching macOS-12, the job sits in the queue indefinitely — it will never be picked up.

Fix: Update the runs-on values in .github/workflows/ios-kit-release.yml from macOS-12 to a supported runner

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SDKE-1162