### PR TITLE
feat: Support UserIdentificationType

### DIFF
--- a/Sources/mParticle-AppsFlyer/MPKitAppsFlyer.m
+++ b/Sources/mParticle-AppsFlyer/MPKitAppsFlyer.m
@@ -19,6 +19,9 @@ NSString *const MPKitAppsFlyerErrorDomain = @"mParticle-AppsFlyer";
 NSString *const afAppleAppId = @"appleAppId";
 NSString *const afDevKey = @"devKey";
 NSString *const afManualStart = @"manualStart";
+NSString *const afUserIdentificationType = @"userIdentificationType";
+NSString *const afUserIdentificationMPID = @"MPID";
+NSString *const afUserIdentificationCustomerId = @"CustomerId";
 NSString *const afAppsFlyerIdIntegrationKey = @"appsflyer_id_integration_setting";
 NSString *const kMPKAFCustomerUserId = @"af_customer_user_id";
 
@@ -112,7 +115,9 @@ static id<AppsFlyerLibDelegate> temporaryDelegate = nil;
     appsFlyerTracker.deepLinkDelegate = self;
     
     _configuration = configuration;
-    
+
+    [self updateCustomerUserIDIfNeededForUser:[self currentUser]];
+
     [self updateConsent];
     [appsFlyerTracker waitForATTUserAuthorizationWithTimeoutInterval:60];
     [self start];
@@ -198,8 +203,13 @@ static id<AppsFlyerLibDelegate> temporaryDelegate = nil;
 - (nonnull MPKitExecStatus *)setUserIdentity:(nullable NSString *)identityString identityType:(MPUserIdentity)identityType {
     MPKitExecStatus *execStatus;
     if (identityType == MPUserIdentityCustomerId) {
-        [appsFlyerTracker setCustomerUserID:identityString];
-        execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeSuccess];
+        if ([self isUserIdentificationMPID]) {
+            // MPID mode: AppsFlyer customer user ID is set from MPID via identity callbacks, not from this API.
+            execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeSuccess];
+        } else {
+            [appsFlyerTracker setCustomerUserID:identityString];
+            execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeSuccess];
+        }
     } else if (identityType == MPUserIdentityEmail) {
         if (identityString) {
             [appsFlyerTracker setUserEmails:@[identityString] withCryptType:EmailCryptTypeNone];
@@ -212,6 +222,26 @@ static id<AppsFlyerLibDelegate> temporaryDelegate = nil;
         execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeFail];
     }
     return execStatus;
+}
+
+- (nonnull MPKitExecStatus *)onIdentifyComplete:(nonnull FilteredMParticleUser *)user request:(nonnull FilteredMPIdentityApiRequest *)request {
+    [self updateCustomerUserIDIfNeededForUser:user];
+    return [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeSuccess];
+}
+
+- (nonnull MPKitExecStatus *)onLoginComplete:(nonnull FilteredMParticleUser *)user request:(nonnull FilteredMPIdentityApiRequest *)request {
+    [self updateCustomerUserIDIfNeededForUser:user];
+    return [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeSuccess];
+}
+
+- (nonnull MPKitExecStatus *)onLogoutComplete:(nonnull FilteredMParticleUser *)user request:(nonnull FilteredMPIdentityApiRequest *)request {
+    [self updateCustomerUserIDIfNeededForUser:user];
+    return [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeSuccess];
+}
+
+- (nonnull MPKitExecStatus *)onModifyComplete:(nonnull FilteredMParticleUser *)user request:(nonnull FilteredMPIdentityApiRequest *)request {
+    [self updateCustomerUserIDIfNeededForUser:user];
+    return [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAppsFlyer) returnCode:MPKitReturnCodeSuccess];
 }
 
 + (NSString * _Nullable)generateProductIdList:(nullable MPCommerceEvent *)event {
@@ -256,7 +286,7 @@ static id<AppsFlyerLibDelegate> temporaryDelegate = nil;
     
     // If a customer id is available, add it to the commerce event user defined attributes
     FilteredMParticleUser *user = [self currentUser];
-    NSString *customerId = [user.userId stringValue];
+    NSString *customerId = [self customerIDForAppsFlyer:user];
     if (customerId.length) {
         MPCommerceEvent *surrogateCommerceEvent = [commerceEvent copy];
         NSMutableDictionary *mutableInfo = surrogateCommerceEvent.customAttributes ? [surrogateCommerceEvent.customAttributes mutableCopy] : [NSMutableDictionary dictionary];
@@ -370,7 +400,7 @@ static id<AppsFlyerLibDelegate> temporaryDelegate = nil;
     
     // If a customer id is available, add it to the event attributes
     FilteredMParticleUser *user = [self currentUser];
-    NSString *customerId = [user.userId stringValue];
+    NSString *customerId = [self customerIDForAppsFlyer:user];
     if (customerId.length) {
         MPEvent *surrogateEvent = [event copy];
         NSMutableDictionary *mutableInfo = surrogateEvent.customAttributes ? [surrogateEvent.customAttributes mutableCopy] : [NSMutableDictionary dictionary];
@@ -573,6 +603,32 @@ static id<AppsFlyerLibDelegate> temporaryDelegate = nil;
 
 - (FilteredMParticleUser *)currentUser {
     return [[self kitApi] getCurrentUserWithKit:self];
+}
+
+- (BOOL)isUserIdentificationMPID {
+    return [afUserIdentificationMPID isEqualToString:_configuration[afUserIdentificationType]];
+}
+
+- (BOOL)isUserIdentificationCustomerId {
+    return [afUserIdentificationCustomerId isEqualToString:_configuration[afUserIdentificationType]];
+}
+
+- (NSString *)customerIDForAppsFlyer:(FilteredMParticleUser *)user {
+    if ([self isUserIdentificationMPID]) {
+        return [user.userId stringValue];
+    } else if ([self isUserIdentificationCustomerId]) {
+        return user.userIdentities[@(MPUserIdentityCustomerId)];
+    } else {
+        // Fallback to MPID as was the default behavior before the new user identification types were introduced
+        return [user.userId stringValue];
+    }
+}
+
+- (void)updateCustomerUserIDIfNeededForUser:(FilteredMParticleUser *)user {
+    if ([self isUserIdentificationMPID] || [self isUserIdentificationCustomerId]) {
+        NSString *customerId = [self customerIDForAppsFlyer:user];
+        [appsFlyerTracker setCustomerUserID:customerId];
+    }
 }
 
 @end

--- a/mParticle_AppsFlyerTests/AppsFlyerLibMock.swift
+++ b/mParticle_AppsFlyerTests/AppsFlyerLibMock.swift
@@ -12,9 +12,21 @@ class AppsFlyerLibMock: AppsFlyerLib {
     var logEventEventName: String?
     var logEventValues: [AnyHashable : Any]?
     var startCallCount = 0
+    var setCustomerUserIDCallCount = 0
+    var lastCustomerUserID: String?
 
     override func start() {
         startCallCount += 1
+    }
+
+    /// `AppsFlyerLib` uses the `customerUserID` property; the kit sets it via `setCustomerUserID:`.
+    override var customerUserID: String? {
+        get { super.customerUserID }
+        set {
+            setCustomerUserIDCallCount += 1
+            lastCustomerUserID = newValue
+            super.customerUserID = newValue
+        }
     }
 
     override func logEvent(_ eventName: String, withValues values: [AnyHashable : Any]?) {

--- a/mParticle_AppsFlyerTests/MPKitAppsFlyerTests.swift
+++ b/mParticle_AppsFlyerTests/MPKitAppsFlyerTests.swift
@@ -103,6 +103,61 @@ final class MPKitAppsFlyerTests: XCTestCase {
         XCTAssertEqual(mock.startCallCount, 1)
     }
 
+    // MARK: - setUserIdentity / userIdentificationType
+
+    func test_setUserIdentity_customerId_legacy_forwardsToAppsFlyer() {
+        kit.configuration = [:]
+        kit.providerKitInstance = mock
+
+        let status = kit.setUserIdentity("ext-cust-1", identityType: .customerId)
+
+        XCTAssertEqual(status.returnCode, .success)
+        XCTAssertEqual(mock.setCustomerUserIDCallCount, 1)
+        XCTAssertEqual(mock.lastCustomerUserID, "ext-cust-1")
+    }
+
+    func test_setUserIdentity_customerId_customerIdMode_forwardsToAppsFlyer() {
+        kit.configuration = ["userIdentificationType": "CustomerId"]
+        kit.providerKitInstance = mock
+
+        let status = kit.setUserIdentity("ext-cust-2", identityType: .customerId)
+
+        XCTAssertEqual(status.returnCode, .success)
+        XCTAssertEqual(mock.setCustomerUserIDCallCount, 1)
+        XCTAssertEqual(mock.lastCustomerUserID, "ext-cust-2")
+    }
+
+    func test_setUserIdentity_customerId_mpidMode_doesNotCallSetCustomerUserID() {
+        kit.configuration = ["userIdentificationType": "MPID"]
+        kit.providerKitInstance = mock
+
+        let status = kit.setUserIdentity("ext-cust-ignored", identityType: .customerId)
+
+        XCTAssertEqual(status.returnCode, .success)
+        XCTAssertEqual(mock.setCustomerUserIDCallCount, 0)
+        XCTAssertNil(mock.lastCustomerUserID)
+    }
+
+    func test_setUserIdentity_email_doesNotUseCustomerUserIDPath() {
+        kit.configuration = ["userIdentificationType": "MPID"]
+        kit.providerKitInstance = mock
+
+        let status = kit.setUserIdentity("a@b.com", identityType: .email)
+
+        XCTAssertEqual(status.returnCode, .success)
+        XCTAssertEqual(mock.setCustomerUserIDCallCount, 0)
+    }
+
+    func test_setUserIdentity_unsupportedIdentity_returnsFail() {
+        kit.configuration = [:]
+        kit.providerKitInstance = mock
+
+        let status = kit.setUserIdentity("x", identityType: .other)
+
+        XCTAssertEqual(status.returnCode, .fail)
+        XCTAssertEqual(mock.setCustomerUserIDCallCount, 0)
+    }
+
     // MARK: - resolvedConsentForMappingKey
 
     func test_resolvedConsentForMappingKey_withGDPRMapping_returnsTrue() {


### PR DESCRIPTION
## Summary
 - Adds userIdentificationType so AppsFlyer’s customer user ID can follow MPID, CustomerId, or legacy behavior, including launch/identity-callback sync and commerce af_customer_user_id via customerIDForAppsFlyer:.
 - setUserIdentity is updated so MPID mode ignores customer-ID identity for AppsFlyer’s customer user ID but still returns success, while legacy and CustomerId mode keep forwarding that identity to AppsFlyer.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - The mock now records writes to AppsFlyer’s customerUserID property (the real SDK path) so tests can assert when the kit sets it.
 - New tests cover setUserIdentity for legacy, CustomerId, and MPID modes plus email and unsupported identity types, alongside the existing manualStart / didBecomeActive checks.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
