### PR TITLE
fix: Guard against nil customerID in updateCustomerUserIDIfNeededForUser

### DIFF
--- a/Sources/mParticle-AppsFlyer/MPKitAppsFlyer.m
+++ b/Sources/mParticle-AppsFlyer/MPKitAppsFlyer.m
@@ -627,7 +627,9 @@ static id<AppsFlyerLibDelegate> temporaryDelegate = nil;
 - (void)updateCustomerUserIDIfNeededForUser:(FilteredMParticleUser *)user {
     if ([self isUserIdentificationMPID] || [self isUserIdentificationCustomerId]) {
         NSString *customerId = [self customerIDForAppsFlyer:user];
-        [appsFlyerTracker setCustomerUserID:customerId];
+        if (customerId.length) {
+            [appsFlyerTracker setCustomerUserID:customerId];
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Guard `setCustomerUserID:` with `customerId.length` in `updateCustomerUserIDIfNeededForUser:` so it is only called when a valid, non-empty CUID is available, consistent with the existing guard pattern used in `routeCommerceEvent:` and `routeEvent:`.
- This aligns with [AppsFlyer's documented pattern](https://dev.appsflyer.com/hc/docs/integrate-ios-sdk#setting-the-customer-user-id) which checks for both nil and empty strings before setting the CUID, and avoids passing nil or empty string to `setCustomerUserID:` on logout.

## Testing Plan
- [x] Was this tested locally? If not, explain why.
Tests added in monorepo

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)
- NO JIRA