### PR TITLE
feat: add NoLocation subspec to CocoaPods podspec

### DIFF
--- a/mParticle-AppsFlyer.podspec
+++ b/mParticle-AppsFlyer.podspec
@@ -19,6 +19,15 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "12.0"
     s.ios.source_files      = 'Sources/**/*.{h,m,mm}'
     s.ios.resource_bundles  = { 'mParticle-AppsFlyer-Privacy' => ['Sources/mParticle-AppsFlyer/PrivacyInfo.xcprivacy'] }
-    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.19'
     s.ios.dependency 'AppsFlyerFramework', '~> 6.16'
+
+    s.default_subspec = 'Standard'
+
+    s.subspec 'Standard' do |ss|
+        ss.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.19'
+    end
+
+    s.subspec 'NoLocation' do |ss|
+        ss.ios.dependency 'mParticle-Apple-SDK/mParticleNoLocation', '~> 8.19'
+    end
 end

--- a/mParticle-AppsFlyer.podspec
+++ b/mParticle-AppsFlyer.podspec
@@ -17,17 +17,20 @@ Pod::Spec.new do |s|
     s.static_framework = true
 
     s.ios.deployment_target = "12.0"
-    s.ios.source_files      = 'Sources/**/*.{h,m,mm}'
-    s.ios.resource_bundles  = { 'mParticle-AppsFlyer-Privacy' => ['Sources/mParticle-AppsFlyer/PrivacyInfo.xcprivacy'] }
-    s.ios.dependency 'AppsFlyerFramework', '~> 6.16'
 
     s.default_subspec = 'Standard'
 
     s.subspec 'Standard' do |ss|
+        ss.ios.source_files      = 'Sources/**/*.{h,m,mm}'
+        ss.ios.resource_bundles  = { 'mParticle-AppsFlyer-Privacy' => ['Sources/mParticle-AppsFlyer/PrivacyInfo.xcprivacy'] }
+        ss.ios.dependency 'AppsFlyerFramework', '~> 6.16'
         ss.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.19'
     end
 
     s.subspec 'NoLocation' do |ss|
+        ss.ios.source_files      = 'Sources/**/*.{h,m,mm}'
+        ss.ios.resource_bundles  = { 'mParticle-AppsFlyer-Privacy' => ['Sources/mParticle-AppsFlyer/PrivacyInfo.xcprivacy'] }
+        ss.ios.dependency 'AppsFlyerFramework', '~> 6.16'
         ss.ios.dependency 'mParticle-Apple-SDK/mParticleNoLocation', '~> 8.19'
     end
 end


### PR DESCRIPTION
## Summary
- Adds a `NoLocation` subspec to the `mParticle-AppsFlyer` podspec that depends on `mParticle-Apple-SDK/mParticleNoLocation`, mirroring the existing SPM product (`mParticle-AppsFlyer-NoLocation`) so CocoaPods consumers can opt into the location-free variant of the core SDK.
- Sets `default_subspec = 'Standard'` and moves the previous hard-coded `mParticle-Apple-SDK/mParticle` dependency into the `Standard` subspec, keeping the default consumer experience (`pod 'mParticle-AppsFlyer'`) fully backward-compatible.
- NoLocation consumers now use `pod 'mParticle-AppsFlyer/NoLocation'` alongside `pod 'mParticle-Apple-SDK/mParticleNoLocation'`, eliminating the subspec mismatch that previously pulled location-aware SDK code into NoLocation projects.

## Testing Plan
- [x] Was this tested locally? If not, explain why.
- `pod ipc spec mParticle-AppsFlyer.podspec` parses cleanly; both subspecs resolve to the expected core SDK subspec.
- `pod lib lint mParticle-AppsFlyer.podspec --allow-warnings` passes validation for both `mParticle-AppsFlyer/Standard` and `mParticle-AppsFlyer/NoLocation`.
- No changes to source files, build scripts, or project files, so existing unit tests and the XCFramework build script are unaffected.

## Reference Issue (For mParticle employees only. Ignore if you are an outside contributor)
- NO JIRA