### PR TITLE
feat: Add startAppsFlyer convenience API

### DIFF
--- a/Sources/mParticle-AppsFlyer/MPKitAppsFlyer.m
+++ b/Sources/mParticle-AppsFlyer/MPKitAppsFlyer.m
@@ -83,7 +83,7 @@ static id<AppsFlyerLibDelegate> temporaryDelegate = nil;
     }
 }
 
-+ (BOOL)startManually {
++ (BOOL)startAppsFlyer {
     if (appsFlyerTracker == nil) {
         return NO;
     }

--- a/Sources/mParticle-AppsFlyer/MPKitAppsFlyer.m
+++ b/Sources/mParticle-AppsFlyer/MPKitAppsFlyer.m
@@ -83,6 +83,15 @@ static id<AppsFlyerLibDelegate> temporaryDelegate = nil;
     }
 }
 
++ (BOOL)startManually {
+    if (appsFlyerTracker == nil) {
+        return NO;
+    }
+
+    [appsFlyerTracker start];
+    return YES;
+}
+
 + (NSNumber *)kitCode {
     return @92;
 }

--- a/Sources/mParticle-AppsFlyer/include/MPKitAppsFlyer.h
+++ b/Sources/mParticle-AppsFlyer/include/MPKitAppsFlyer.h
@@ -23,7 +23,7 @@ extern NSString * _Nonnull const MPKitAppsFlyerErrorDomain;
 @property (nonatomic, strong, nullable) id providerKitInstance;
 
 + (void)setDelegate:(id _Nonnull)delegate;
-+ (BOOL)startManually;
++ (BOOL)startAppsFlyer;
 + (NSNumber * _Nonnull)computeProductQuantity:(nullable MPCommerceEvent *)event;
 + (NSString * _Nullable)generateProductIdList:(nullable MPCommerceEvent *)event;
 

--- a/Sources/mParticle-AppsFlyer/include/MPKitAppsFlyer.h
+++ b/Sources/mParticle-AppsFlyer/include/MPKitAppsFlyer.h
@@ -23,6 +23,7 @@ extern NSString * _Nonnull const MPKitAppsFlyerErrorDomain;
 @property (nonatomic, strong, nullable) id providerKitInstance;
 
 + (void)setDelegate:(id _Nonnull)delegate;
++ (BOOL)startManually;
 + (NSNumber * _Nonnull)computeProductQuantity:(nullable MPCommerceEvent *)event;
 + (NSString * _Nullable)generateProductIdList:(nullable MPCommerceEvent *)event;
 


### PR DESCRIPTION
## Background
When `manualStart` is enabled, clients need a simple way to trigger AppsFlyer start through the kit-managed instance.

The current approach can be unclear in integrations where the raw AppsFlyer SDK is not directly exposed at app level.
To make this explicit and easier to use, we are adding a dedicated public wrapper method on `MPKitAppsFlyer`.

## What Has Changed
- Added a new public class method:
  - `+ (BOOL)startAppsFlyer;`
- Implemented the method to:
  - return `NO` if the AppsFlyer tracker is not initialized
  - call `[appsFlyerTracker start]` and return `YES` when available
- Renamed the initial method name from `startManually` to `startAppsFlyer` for clarity.

## Screenshots/Video
N/A

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes
Before:
- No dedicated public wrapper method to explicitly trigger AppsFlyer start via the kit API.

After:
- Clients can call:
  - `MPKitAppsFlyer.start()`

## Reference Issue (For employees only. Ignore if you are an outside contributor)
Closes N/A