### PR TITLE
feat: Log warning for early manual AppsFlyer start

### DIFF
--- a/Sources/mParticle-AppsFlyer/MPKitAppsFlyer.m
+++ b/Sources/mParticle-AppsFlyer/MPKitAppsFlyer.m
@@ -85,6 +85,8 @@ static id<AppsFlyerLibDelegate> temporaryDelegate = nil;
 
 + (BOOL)startAppsFlyer {
     if (appsFlyerTracker == nil) {
+        NSLog(@"Warning: `startAppsFlyer` was called before AppsFlyer was initialized by mParticle. "
+              "Ensure the kit is configured and active before invoking manual start.");
         return NO;
     }
 


### PR DESCRIPTION
## Background
`MPKitAppsFlyer.startAppsFlyer()` can be called before the AppsFlyer tracker is initialized by the kit.
In that case, the method returns `NO`, but there is no explicit runtime warning explaining why startup did not happen.

## What Has Changed
- added a warning log in `startAppsFlyer` when it is called before tracker initialization
- preserved existing behavior (`NO` is still returned and no start call is attempted)

## Screenshots/Video
N/A

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes
Before:
- Calling `startAppsFlyer` too early returned `NO` without a clear runtime warning.

After:
- Calling `startAppsFlyer` too early returns `NO` and logs a warning with guidance.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
Closes N/A